### PR TITLE
Fix import that caused issues in dependencies

### DIFF
--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -1,5 +1,5 @@
 import log from '@connectedcars/logutil'
-import EventEmitter from 'events'
+import { EventEmitter } from 'events'
 import http from 'http'
 import net from 'net'
 import { URL } from 'url'


### PR DESCRIPTION
Part of [[sc-113128](https://app.shortcut.com/connectedcars/story/113128)]
[skip-sc]
Caused "Type 'typeof EventEmitter' is not a constructor function type"